### PR TITLE
fixed getSelectedCountryCodeAsInt return value

### DIFF
--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -628,7 +628,7 @@ public class CountryCodePicker extends RelativeLayout {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return 0;
+        return code;
     }
 
     /**


### PR DESCRIPTION
getDefaultCountryCodeAsInt always returned 0. Fixed with one-liner change.