### PR TITLE
Add possibility to hide search edit text and make use of system locale

### DIFF
--- a/ccp/src/main/java/com/hbb20/CountryCodeAdapter.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodeAdapter.java
@@ -38,7 +38,11 @@ class CountryCodeAdapter extends RecyclerView.Adapter<CountryCodeAdapter.Country
         this.textView_noResult = textView_noResult;
         this.editText_search = editText_search;
         this.inflater = LayoutInflater.from(context);
-        setTextWatcher();
+        if (this.codePicker.showSearch) {
+            setTextWatcher();
+        } else {
+          this.editText_search.setVisibility(View.GONE);
+        }
         this.filteredCountries = getFilteredCountries("");
     }
 

--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Created by hbb20 on 11/1/16.
@@ -127,12 +128,19 @@ public class CountryCodePicker extends RelativeLayout {
             //autopop keyboard
             setKeyboardAutoPopOnSearch(a.getBoolean(R.styleable.CountryCodePicker_keyboardAutoPopOnSearch, true));
 
-            //if custom language is specified, then set it as custom
             int attrLanguage = LANGUAGE_ENGLISH;
+            customLanguage = getLanguageEnum(attrLanguage);
+
+            //if use system locale is specified, use this but give custom locale priority
+            if(a.hasValue(R.styleable.CountryCodePicker_useSystemLocale)){
+                customLanguage = Language.fromLocal(getCurrentLocale());
+            }
+
+            //if custom language is specified, then set it as custom
             if (a.hasValue(R.styleable.CountryCodePicker_ccpLanguage)) {
                 attrLanguage = a.getInt(R.styleable.CountryCodePicker_ccpLanguage, 1);
+                customLanguage = getLanguageEnum(attrLanguage);
             }
-            customLanguage = getLanguageEnum(attrLanguage);
 
             //custom master list
             customMasterCountries = a.getString(R.styleable.CountryCodePicker_customMasterCountries);
@@ -1000,7 +1008,25 @@ public class CountryCodePicker extends RelativeLayout {
 
     //add here so that language can be set programmatically
     public enum Language {
-        ARABIC, BENGALI, CHINESE, ENGLISH, FRENCH, GERMAN, GUJARATI, HINDI, JAPANESE, JAVANESE, PORTUGUESE, RUSSIAN, SPANISH
+        ARABIC("ar"), BENGALI("bn"), CHINESE("zh"), ENGLISH("en"), FRENCH("fr"), GERMAN("de"), GUJARATI("gu"), HINDI("hi"), JAPANESE("ja"), JAVANESE("jv"), PORTUGUESE("pt"), RUSSIAN("ru"), SPANISH("es");
+        String ISO2Code;
+        Language(String ISO2Code) {
+            this.ISO2Code = ISO2Code;
+        }
+        String getISO2Code() {
+            return ISO2Code;
+        }
+
+        static Language fromLocal(Locale locale){
+
+
+            for(Language language : Language.values()){
+                if (locale.getLanguage().equalsIgnoreCase(language.getISO2Code())) {
+                    return language;
+                }
+            }
+            return ENGLISH;
+        }
     }
 
     /*
@@ -1008,5 +1034,9 @@ public class CountryCodePicker extends RelativeLayout {
      */
     public interface OnCountryChangeListener {
         void onCountrySelected();
+    }
+
+    public Locale getCurrentLocale(){
+        return getResources().getConfiguration().locale;
     }
 }

--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -57,6 +57,7 @@ public class CountryCodePicker extends RelativeLayout {
     CountryCodePicker codePicker;
     boolean hideNameCode = false;
     boolean showFlag = true;
+    boolean showSearch = true;
     boolean showFullName = false;
     boolean useFullName = false;
     int contentColor;
@@ -196,6 +197,9 @@ public class CountryCodePicker extends RelativeLayout {
             if (arrowSize > 0) {
                 setArrowSize(arrowSize);
             }
+
+            //show search
+            showSearch(a.getBoolean(R.styleable.CountryCodePicker_showSearch, true));
 
         } catch (Exception e) {
             textView_selectedCountry.setText(e.getMessage());
@@ -976,6 +980,10 @@ public class CountryCodePicker extends RelativeLayout {
         } else {
             linearFlagHolder.setVisibility(GONE);
         }
+    }
+
+    private void showSearch(boolean showSearch) {
+        this.showSearch = showSearch;
     }
 
     public void showFullName(boolean showFullName) {

--- a/ccp/src/main/res/values/attrs.xml
+++ b/ccp/src/main/res/values/attrs.xml
@@ -28,5 +28,6 @@
         <attr name="showFlag" format="boolean" />
         <attr name="showFullName" format="boolean" />
         <attr name="showSearch" format="boolean"/>
+        <attr name="useSystemLocale" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/ccp/src/main/res/values/attrs.xml
+++ b/ccp/src/main/res/values/attrs.xml
@@ -27,5 +27,6 @@
         <attr name="customMasterCountries" format="string" />
         <attr name="showFlag" format="boolean" />
         <attr name="showFullName" format="boolean" />
+        <attr name="showSearch" format="boolean"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Added the possibility to hide the search edit text, which is useful for rather small lists or style purposes. Furthermore, added the possibility to use the default system locale for determining the language used in the picker dialog instead of defining one. This is useful for internationalised apps.