### PR TITLE
Enhanced keyboard handling on landscape screeb orientation

### DIFF
--- a/ccp/src/main/res/layout/layout_picker_dialog.xml
+++ b/ccp/src/main/res/layout/layout_picker_dialog.xml
@@ -20,6 +20,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/textView_title"
         android:hint="@string/search_hint"
+        android:imeOptions="flagNoExtractUi"
         android:singleLine="true"
         android:textColor="@android:color/primary_text_light_nodisable" />
 


### PR DESCRIPTION
Used android:imeOptions="flagNoExtractUi" for the country search. This will prevent the full-screen keyboard in landscape orientation.