### PR TITLE
Resolve issue #110 

### DIFF
--- a/ccp/src/main/java/com/hbb20/Country.java
+++ b/ccp/src/main/java/com/hbb20/Country.java
@@ -88,7 +88,8 @@ class Country implements Comparable<Country> {
         try {
             XmlPullParserFactory xmlFactoryObject = XmlPullParserFactory.newInstance();
             XmlPullParser xmlPullParser = xmlFactoryObject.newPullParser();
-            InputStream ins = context.getResources().openRawResource(context.getResources().getIdentifier(language.toString().toLowerCase(), "raw", context.getPackageName()));
+            InputStream ins = context.getResources().openRawResource(context.getResources().getIdentifier(language
+                .toString().toLowerCase(Locale.ROOT), "raw", context.getPackageName()));
             xmlPullParser.setInput(ins, null);
             int event = xmlPullParser.getEventType();
             while (event != XmlPullParser.END_DOCUMENT) {


### PR DESCRIPTION
Apply Locale.ROOT and make sure than 'i' sta…ys 'i' and does not become 'ı' when locale is set to turkish. 'ı' caused the loading of the country list to fail.

More info about the issue can be found here (this was a similar issue) https://github.com/google/gson/issues/541