### PR TITLE
remove explicit allowBackup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="in.hbb20.countrycodepickerproject">
 
     <application
-        android:allowBackup="true"
         android:icon="@drawable/ic_ccp_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
The following line from the android manifest forces users of this library to use tools:replace="android:allowBackup" when switching to android:allowBackup="false" in their manifest:

     <application ... android:allowBackup="true" ...>

`allowBackup=true` is implicit. If there's no special reason for having this explicitly added to the lib's manifest I'd suggest to drop it.