### PR TITLE
Fix typo in updateHint method for pre-lollipop.

### DIFF
--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -823,7 +823,7 @@ public class CountryCodePicker extends RelativeLayout {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     formattedNumber = PhoneNumberUtils.formatNumber(getSelectedCountryCodeWithPlus() + formattedNumber, getSelectedCountryNameCode());
                 } else {
-                    formattedNumber = PhoneNumberUtils.formatNumber(getSelectedCountryCodeWithPlus() + formattedNumber + formattedNumber);
+                    formattedNumber = PhoneNumberUtils.formatNumber(getSelectedCountryCodeWithPlus() + formattedNumber);
                 }
                 formattedNumber = formattedNumber.substring(getSelectedCountryCodeWithPlus().length()).trim();
                 Log.d(TAG, "updateHint: after format " + formattedNumber + " " + selectionMemoryTag);


### PR DESCRIPTION
Phone number in hint were duplicated when using library on pre-lollipop due to typo.