### PR TITLE
Support national number formatting

### DIFF
--- a/ccp/src/main/java/com/hbb20/CountryCodeAdapter.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodeAdapter.java
@@ -125,10 +125,10 @@ class CountryCodeAdapter extends RecyclerView.Adapter<CountryCodeAdapter.Country
 
         //if query started from "+" ignore it
         if (query.length() > 0 && query.charAt(0) == '+') {
-            query=query.substring(1);
+            query = query.substring(1);
         }
 
-        filteredCountries= getFilteredCountries(query);
+        filteredCountries = getFilteredCountries(query);
 
         if (filteredCountries.size() == 0) {
             textView_noResult.setVisibility(View.VISIBLE);
@@ -139,7 +139,7 @@ class CountryCodeAdapter extends RecyclerView.Adapter<CountryCodeAdapter.Country
     private List<CCPCountry> getFilteredCountries(String query) {
         List<CCPCountry> tempCCPCountryList = new ArrayList<CCPCountry>();
         preferredCountriesCount = 0;
-        if(codePicker.preferredCountries!=null && codePicker.preferredCountries.size()>0) {
+        if (codePicker.preferredCountries != null && codePicker.preferredCountries.size() > 0) {
             for (CCPCountry CCPCountry : codePicker.preferredCountries) {
                 if (CCPCountry.isEligibleForQuery(query)) {
                     tempCCPCountryList.add(CCPCountry);
@@ -279,7 +279,7 @@ class CountryCodeAdapter extends RecyclerView.Adapter<CountryCodeAdapter.Country
                     linearFlagHolder.setVisibility(View.VISIBLE);
                     imageViewFlag.setImageResource(ccpCountry.getFlagID());
                 }
-            }else{
+            } else {
                 divider.setVisibility(View.VISIBLE);
                 textView_name.setVisibility(View.GONE);
                 textView_code.setVisibility(View.GONE);

--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -85,6 +85,7 @@ public class CountryCodePicker extends RelativeLayout {
     boolean ccpDialogInitialScrollToSelection = false;
     boolean ccpUseEmoji = false;
     boolean ccpUseDummyEmojiForPreview = false;
+    boolean internationalFormattingOnly = true;
     PhoneNumberType hintExampleNumberType = PhoneNumberType.MOBILE;
     String selectionMemoryTag = "ccp_last_selection";
     int contentColor = DEFAULT_UNSET;
@@ -176,6 +177,22 @@ public class CountryCodePicker extends RelativeLayout {
         }
     }
 
+	private boolean isInternationalFormattingOnlyEnabled() {
+		return internationalFormattingOnly;
+	}
+
+	/**
+	 * This will set boolean for internationalFormattingOnly and refresh formattingTextWatcher
+	 *
+	 * @param internationalFormattingOnly
+	 */
+	public void setInternationalFormattingOnly(boolean internationalFormattingOnly) {
+		this.internationalFormattingOnly = internationalFormattingOnly;
+		if (editText_registeredCarrierNumber != null) {
+			updateFormattingTextWatcher();
+		}
+	}
+
     private void init(AttributeSet attrs) {
         mInflater = LayoutInflater.from(context);
 
@@ -266,7 +283,10 @@ public class CountryCodePicker extends RelativeLayout {
             //example number hint enabled?
             hintExampleNumberEnabled = a.getBoolean(R.styleable.CountryCodePicker_ccp_hintExampleNumber, false);
 
-            //example number hint type
+			//international formatting only
+			internationalFormattingOnly = a.getBoolean(R.styleable.CountryCodePicker_ccp_internationalFormattingOnly, true);
+
+			//example number hint type
             int hintNumberTypeIndex = a.getInt(R.styleable.CountryCodePicker_ccp_hintExampleNumberType, 0);
             hintExampleNumberType = PhoneNumberType.values()[hintNumberTypeIndex];
 
@@ -932,7 +952,7 @@ public class CountryCodePicker extends RelativeLayout {
             }
 
             if (numberAutoFormattingEnabled) {
-                formattingTextWatcher = new InternationalPhoneTextWatcher(context, getSelectedCountryNameCode(), getSelectedCountryCodeAsInt());
+                formattingTextWatcher = new InternationalPhoneTextWatcher(context, getSelectedCountryNameCode(), getSelectedCountryCodeAsInt(), internationalFormattingOnly);
                 editText_registeredCarrierNumber.addTextChangedListener(formattingTextWatcher);
             }
 

--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -177,21 +177,21 @@ public class CountryCodePicker extends RelativeLayout {
         }
     }
 
-	private boolean isInternationalFormattingOnlyEnabled() {
-		return internationalFormattingOnly;
-	}
+    private boolean isInternationalFormattingOnlyEnabled() {
+        return internationalFormattingOnly;
+    }
 
-	/**
-	 * This will set boolean for internationalFormattingOnly and refresh formattingTextWatcher
-	 *
-	 * @param internationalFormattingOnly
-	 */
-	public void setInternationalFormattingOnly(boolean internationalFormattingOnly) {
-		this.internationalFormattingOnly = internationalFormattingOnly;
-		if (editText_registeredCarrierNumber != null) {
-			updateFormattingTextWatcher();
-		}
-	}
+    /**
+     * This will set boolean for internationalFormattingOnly and refresh formattingTextWatcher
+     *
+     * @param internationalFormattingOnly
+     */
+    public void setInternationalFormattingOnly(boolean internationalFormattingOnly) {
+        this.internationalFormattingOnly = internationalFormattingOnly;
+        if (editText_registeredCarrierNumber != null) {
+            updateFormattingTextWatcher();
+        }
+    }
 
     private void init(AttributeSet attrs) {
         mInflater = LayoutInflater.from(context);
@@ -283,10 +283,10 @@ public class CountryCodePicker extends RelativeLayout {
             //example number hint enabled?
             hintExampleNumberEnabled = a.getBoolean(R.styleable.CountryCodePicker_ccp_hintExampleNumber, false);
 
-			//international formatting only
-			internationalFormattingOnly = a.getBoolean(R.styleable.CountryCodePicker_ccp_internationalFormattingOnly, true);
+            //international formatting only
+            internationalFormattingOnly = a.getBoolean(R.styleable.CountryCodePicker_ccp_internationalFormattingOnly, true);
 
-			//example number hint type
+            //example number hint type
             int hintNumberTypeIndex = a.getInt(R.styleable.CountryCodePicker_ccp_hintExampleNumberType, 0);
             hintExampleNumberType = PhoneNumberType.values()[hintNumberTypeIndex];
 

--- a/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
+++ b/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
@@ -35,23 +35,23 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
 
     private boolean internationalOnly;
 
-	/**
-	 * @param context
-	 * @param countryNameCode  ISO 3166-1 two-letter country code that indicates the country/region
-	 *                         where the phone number is being entered.
-	 * @param countryPhoneCode Phone code of country. https://countrycode.org/
-	 */
-	public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode) {
-		this(context, countryNameCode, countryPhoneCode, true);
-	}
+    /**
+     * @param context
+     * @param countryNameCode  ISO 3166-1 two-letter country code that indicates the country/region
+     *                         where the phone number is being entered.
+     * @param countryPhoneCode Phone code of country. https://countrycode.org/
+     */
+    public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode) {
+        this(context, countryNameCode, countryPhoneCode, true);
+    }
 
     /**
      * @param context
      * @param countryNameCode   ISO 3166-1 two-letter country code that indicates the country/region
      *                          where the phone number is being entered.
      * @param countryPhoneCode  Phone code of country. https://countrycode.org/
-	 * @param internationalOnly Specifies whether numbers should only be formatted if they are
-	 *                          international vs national
+     * @param internationalOnly Specifies whether numbers should only be formatted if they are
+     *                          international vs national
      */
     public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode, boolean internationalOnly) {
         if (countryNameCode == null || countryNameCode.length() == 0)
@@ -184,9 +184,9 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
 
         String countryCallingCode = "+" + countryPhoneCode;
 
-		if (internationalOnly || (s.length() > 0 && s.charAt(0) != '0'))
-	        //to have number formatted as international format, add country code before that
-			s = countryCallingCode + s;
+        if (internationalOnly || (s.length() > 0 && s.charAt(0) != '0'))
+            //to have number formatted as international format, add country code before that
+            s = countryCallingCode + s;
         int len = s.length();
 
         for (int i = 0; i < len; i++) {
@@ -203,16 +203,16 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
         }
 
         internationalFormatted = internationalFormatted.trim();
-		if (internationalOnly || (s.length() == 0 || s.charAt(0) != '0')) {
-			if (internationalFormatted.length() > countryCallingCode.length()) {
-				if (internationalFormatted.charAt(countryCallingCode.length()) == ' ')
-					internationalFormatted = internationalFormatted.substring(countryCallingCode.length() + 1);
-				else
-					internationalFormatted = internationalFormatted.substring(countryCallingCode.length());
-			} else {
-				internationalFormatted = "";
-			}
-		}
+        if (internationalOnly || (s.length() == 0 || s.charAt(0) != '0')) {
+            if (internationalFormatted.length() > countryCallingCode.length()) {
+                if (internationalFormatted.charAt(countryCallingCode.length()) == ' ')
+                    internationalFormatted = internationalFormatted.substring(countryCallingCode.length() + 1);
+                else
+                    internationalFormatted = internationalFormatted.substring(countryCallingCode.length());
+            } else {
+                internationalFormatted = "";
+            }
+        }
         return TextUtils.isEmpty(internationalFormatted) ? "" : internationalFormatted;
     }
 

--- a/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
+++ b/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
@@ -170,8 +170,9 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
 
         String countryCallingCode = "+" + countryPhoneCode;
 
-        //to have number formatted as international format, add country code before that
-        s = countryCallingCode + s;
+		if (s.length() > 0 && s.charAt(0) != '0')
+	        //to have number formatted as international format, add country code before that
+			s = countryCallingCode + s;
         int len = s.length();
 
         for (int i = 0; i < len; i++) {
@@ -188,14 +189,16 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
         }
 
         internationalFormatted = internationalFormatted.trim();
-        if (internationalFormatted.length() > countryCallingCode.length()) {
-            if (internationalFormatted.charAt(countryCallingCode.length()) == ' ')
-                internationalFormatted = internationalFormatted.substring(countryCallingCode.length() + 1);
-            else
-                internationalFormatted = internationalFormatted.substring(countryCallingCode.length());
-        } else {
-            internationalFormatted = "";
-        }
+		if (s.length() == 0 || s.charAt(0) != '0') {
+			if (internationalFormatted.length() > countryCallingCode.length()) {
+				if (internationalFormatted.charAt(countryCallingCode.length()) == ' ')
+					internationalFormatted = internationalFormatted.substring(countryCallingCode.length() + 1);
+				else
+					internationalFormatted = internationalFormatted.substring(countryCallingCode.length());
+			} else {
+				internationalFormatted = "";
+			}
+		}
         return TextUtils.isEmpty(internationalFormatted) ? "" : internationalFormatted;
     }
 

--- a/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
+++ b/ccp/src/main/java/com/hbb20/InternationalPhoneTextWatcher.java
@@ -33,18 +33,32 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
     //at this point this will avoid "stopFormatting"
     private boolean needUpdateForCountryChange = false;
 
+    private boolean internationalOnly;
+
+	/**
+	 * @param context
+	 * @param countryNameCode  ISO 3166-1 two-letter country code that indicates the country/region
+	 *                         where the phone number is being entered.
+	 * @param countryPhoneCode Phone code of country. https://countrycode.org/
+	 */
+	public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode) {
+		this(context, countryNameCode, countryPhoneCode, true);
+	}
 
     /**
      * @param context
-     * @param countryNameCode  ISO 3166-1 two-letter country code that indicates the country/region
-     *                         where the phone number is being entered.
-     * @param countryPhoneCode Phone code of country. https://countrycode.org/
+     * @param countryNameCode   ISO 3166-1 two-letter country code that indicates the country/region
+     *                          where the phone number is being entered.
+     * @param countryPhoneCode  Phone code of country. https://countrycode.org/
+	 * @param internationalOnly Specifies whether numbers should only be formatted if they are
+	 *                          international vs national
      */
-    public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode) {
+    public InternationalPhoneTextWatcher(Context context, String countryNameCode, int countryPhoneCode, boolean internationalOnly) {
         if (countryNameCode == null || countryNameCode.length() == 0)
             throw new IllegalArgumentException();
         phoneNumberUtil = PhoneNumberUtil.createInstance(context);
         updateCountry(countryNameCode, countryPhoneCode);
+        this.internationalOnly = internationalOnly;
     }
 
     public void updateCountry(String countryNameCode, int countryPhoneCode) {
@@ -170,7 +184,7 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
 
         String countryCallingCode = "+" + countryPhoneCode;
 
-		if (s.length() > 0 && s.charAt(0) != '0')
+		if (internationalOnly || (s.length() > 0 && s.charAt(0) != '0'))
 	        //to have number formatted as international format, add country code before that
 			s = countryCallingCode + s;
         int len = s.length();
@@ -189,7 +203,7 @@ public class InternationalPhoneTextWatcher implements TextWatcher {
         }
 
         internationalFormatted = internationalFormatted.trim();
-		if (s.length() == 0 || s.charAt(0) != '0') {
+		if (internationalOnly || (s.length() == 0 || s.charAt(0) != '0')) {
 			if (internationalFormatted.length() > countryCallingCode.length()) {
 				if (internationalFormatted.charAt(countryCallingCode.length()) == ' ')
 					internationalFormatted = internationalFormatted.substring(countryCallingCode.length() + 1);

--- a/ccp/src/main/res/values/attrs.xml
+++ b/ccp/src/main/res/values/attrs.xml
@@ -41,6 +41,7 @@
         <attr name="ccp_showNameCode" format="boolean" />
         <attr name="ccp_showFlag" format="boolean" />
         <attr name="ccp_showFullName" format="boolean" />
+	    <attr name="ccp_internationalFormattingOnly" format="boolean" />
         <attr name="ccp_clickable" format="boolean" />
         <attr name="ccp_showPhoneCode" format="boolean" />
         <attr name="ccp_autoDetectLanguage" format="boolean" />


### PR DESCRIPTION
Added support for formatting national numbers as well as an option to disable it (disabled by default). The only bit left is to figure out the best way to display it in the example number, and update the example app to mention it. 

see #287 