### PR TITLE
Fix CCPCountry creation

### DIFF
--- a/ccp/src/main/java/com/hbb20/CCPCountry.java
+++ b/ccp/src/main/java/com/hbb20/CCPCountry.java
@@ -61,7 +61,7 @@ public class CCPCountry implements Comparable<CCPCountry> {
     }
 
     public CCPCountry(String nameCode, String phoneCode, String name, int flagResID) {
-        this.nameCode = nameCode;
+        this.nameCode = nameCode.toUpperCase(Locale.ROOT);
         this.phoneCode = phoneCode;
         this.name = name;
         this.flagResID = flagResID;


### PR DESCRIPTION
Fix issue #307 

upperCase the nameCode when creating the CCPCountry object in order to be consistent between creation from XML or Programmatically