### PR TITLE
remove option textVisiblePassword.

### DIFF
--- a/ccp/src/main/res/layout/layout_picker_dialog.xml
+++ b/ccp/src/main/res/layout/layout_picker_dialog.xml
@@ -51,7 +51,7 @@
             android:hint="@string/search_hint"
             android:imeOptions="actionSearch"
             android:singleLine="true"
-            android:inputType="textNoSuggestions|textVisiblePassword"
+            android:inputType="textNoSuggestions"
             android:textColor="@android:color/primary_text_light_nodisable" />
 
         <ImageView


### PR DESCRIPTION
Because can not input other language keyboard. 
Only English is typed on other language keyboards.