### PR TITLE
Remove app name specification from library

### DIFF
--- a/ccp/src/main/AndroidManifest.xml
+++ b/ccp/src/main/AndroidManifest.xml
@@ -1,10 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.hbb20">
-
-    <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.hbb20"/>

--- a/ccp/src/main/res/values/strings.xml
+++ b/ccp/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">CountryCodePicker</string>
     <string name="search_hint">Search…</string>
     <string name="no_result_found">Results not found</string>
     <string name="select_country">Select a country</string>


### PR DESCRIPTION
Came across this while setting up new flavor in our app and realizing our app name was CountryCodePicker.
Library should not specify application label and app_name string

This should most likely fix #351 as well