### PR TITLE
Added content descriptions to CountryCodeDialog buttons TalkBack accessibility

### DIFF
--- a/ccp/src/main/res/layout/layout_picker_dialog.xml
+++ b/ccp/src/main/res/layout/layout_picker_dialog.xml
@@ -32,6 +32,7 @@
             android:alpha="0.7"
             android:clickable="true"
             android:padding="4dp"
+            android:contentDescription="@string/dismiss_button_content_description"
             android:src="@drawable/ic_clear_black_24dp" />
     </RelativeLayout>
 
@@ -63,6 +64,7 @@
             android:alpha="0.7"
             android:clickable="true"
             android:padding="10dp"
+            android:contentDescription="@string/clear_search_button_content_description"
             android:src="@drawable/ic_backspace_black_24dp" />
     </RelativeLayout>
 

--- a/ccp/src/main/res/values/strings.xml
+++ b/ccp/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="search_hint">Search…</string>
     <string name="no_result_found">Results not found</string>
     <string name="select_country">Select a country</string>
+    <string name="dismiss_button_content_description">Dismiss</string>
+    <string name="clear_search_button_content_description">Clear search</string>
 </resources>


### PR DESCRIPTION
Added content descriptions to CountryCodeDialog to make the dismiss and clear query buttons accessible through TalkBack.

Ontario, Canada has recently introduced legislation mandating that apps are accessible to users with disabilities which will come into force on January 1st, 2021. Unfortunately, parts of your components are not accessible through TalkBack (e.g. the clear query button will read "unlabeled button" rather than a description that helps a visually impaired user understand what the button does). In order to keep using your components and comply with the legislation we will need the content descriptions that I've added here. Please let me know if you'd like anymore info. Thank you!

Reference: https://www.aoda.ca