### PR TITLE
Ccp turkish macedonia change

### DIFF
--- a/ccp/src/main/res/raw/ccp_turkish.xml
+++ b/ccp/src/main/res/raw/ccp_turkish.xml
@@ -698,7 +698,7 @@
             name_code="mh"
             phone_code="692" />
         <country
-            name="Kuzey Makedonya"
+            name="Kuzey Makedonya "
             english_name="Macedonia (FYROM)"
             name_code="mk"
             phone_code="389" />

--- a/ccp/src/main/res/raw/ccp_turkish.xml
+++ b/ccp/src/main/res/raw/ccp_turkish.xml
@@ -698,7 +698,7 @@
             name_code="mh"
             phone_code="692" />
         <country
-            name="Makedonya"
+            name="Kuzey Makedonya"
             english_name="Macedonia (FYROM)"
             name_code="mk"
             phone_code="389" />


### PR DESCRIPTION
The name of the Macedonian country was changed to North Macedonia in the Turkish language.