### PR TITLE
Georgia in german is "Georgien"

### DIFF
--- a/ccp/src/main/res/raw/ccp_german.xml
+++ b/ccp/src/main/res/raw/ccp_german.xml
@@ -383,7 +383,7 @@
             name_code="gd"
             phone_code="1" />
         <country
-            name="Georgia"
+            name="Georgien"
             english_name="Georgia"
             name_code="ge"
             phone_code="995" />


### PR DESCRIPTION
Source: I'm native speaker