### PR TITLE
Update library io.michaelrocks:libphonenumber-android

### DIFF
--- a/ccp/build.gradle
+++ b/ccp/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.core:core:1.6.0'
-    implementation 'io.michaelrocks:libphonenumber-android:8.12.52'
+    implementation 'io.michaelrocks:libphonenumber-android:8.13.48'
     implementation "androidx.cardview:cardview:1.0.0"
 }

--- a/ccp/src/main/java/com/hbb20/CountryCodePicker.java
+++ b/ccp/src/main/java/com/hbb20/CountryCodePicker.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import io.michaelrocks.libphonenumber.android.BuildConfig;
 import io.michaelrocks.libphonenumber.android.NumberParseException;
 import io.michaelrocks.libphonenumber.android.PhoneNumberUtil;
 import io.michaelrocks.libphonenumber.android.Phonenumber;


### PR DESCRIPTION
Update io.michaelrocks:libphonenumber-android to `8.13.48`.

Use case of new numbers from Orange in Burkina Faso did not pass validation on previous version.

<img src="https://github.com/user-attachments/assets/76781959-475c-4ab7-95a8-2e13106554f3" width=250/>